### PR TITLE
[PR] feature-containerView

### DIFF
--- a/GithubFollower/GithubFollower.xcodeproj/project.pbxproj
+++ b/GithubFollower/GithubFollower.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		CDA25DE02ADD24B400D5DED5 /* GFUserInfoHeaderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA25DDF2ADD24B400D5DED5 /* GFUserInfoHeaderViewController.swift */; };
 		CDA25DE22ADD265B00D5DED5 /* GFSecondaryTitleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA25DE12ADD265B00D5DED5 /* GFSecondaryTitleLabel.swift */; };
 		CDA25DE42ADDE5E700D5DED5 /* SFSymbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA25DE32ADDE5E700D5DED5 /* SFSymbols.swift */; };
+		CDA25DE62ADE084900D5DED5 /* GFItemInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA25DE52ADE084900D5DED5 /* GFItemInfoView.swift */; };
+		CDA25DE82ADE0D5300D5DED5 /* ItemInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA25DE72ADE0D5300D5DED5 /* ItemInfoType.swift */; };
 		CDB3C8612AD2199C001D5D3D /* NetworkManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3C8602AD2199C001D5D3D /* NetworkManageable.swift */; };
 		CDB3C8632AD21A0D001D5D3D /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3C8622AD21A0D001D5D3D /* NetworkManager.swift */; };
 		CDB3C86A2AD236C9001D5D3D /* JSONDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3C8692AD236C9001D5D3D /* JSONDecodable.swift */; };
@@ -122,6 +124,8 @@
 		CDA25DDF2ADD24B400D5DED5 /* GFUserInfoHeaderViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GFUserInfoHeaderViewController.swift; sourceTree = "<group>"; };
 		CDA25DE12ADD265B00D5DED5 /* GFSecondaryTitleLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GFSecondaryTitleLabel.swift; sourceTree = "<group>"; };
 		CDA25DE32ADDE5E700D5DED5 /* SFSymbols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbols.swift; sourceTree = "<group>"; };
+		CDA25DE52ADE084900D5DED5 /* GFItemInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GFItemInfoView.swift; sourceTree = "<group>"; };
+		CDA25DE72ADE0D5300D5DED5 /* ItemInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemInfoType.swift; sourceTree = "<group>"; };
 		CDB3C8602AD2199C001D5D3D /* NetworkManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManageable.swift; sourceTree = "<group>"; };
 		CDB3C8622AD21A0D001D5D3D /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		CDB3C8692AD236C9001D5D3D /* JSONDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodable.swift; sourceTree = "<group>"; };
@@ -217,6 +221,7 @@
 				CD8434822AD97BB6006502C0 /* QueryItem.swift */,
 				CD1C829C2ADAA9A500F6DB50 /* Section.swift */,
 				CDA25DE32ADDE5E700D5DED5 /* SFSymbols.swift */,
+				CDA25DE72ADE0D5300D5DED5 /* ItemInfoType.swift */,
 			);
 			path = Enum;
 			sourceTree = "<group>";
@@ -285,6 +290,7 @@
 			children = (
 				CD029E102AD0B6E5003D5FBD /* GFContainerView.swift */,
 				CD1C82B02ADC870100F6DB50 /* GFEmptyStateView.swift */,
+				CDA25DE52ADE084900D5DED5 /* GFItemInfoView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -678,6 +684,7 @@
 				CDA25DE22ADD265B00D5DED5 /* GFSecondaryTitleLabel.swift in Sources */,
 				CDB3C8892AD28631001D5D3D /* URLSessionable.swift in Sources */,
 				221EB7C02ADA2390005044AF /* FollowerCell.swift in Sources */,
+				CDA25DE82ADE0D5300D5DED5 /* ItemInfoType.swift in Sources */,
 				CD1C82A82ADB7CFC00F6DB50 /* ImageCacheManager.swift in Sources */,
 				CD1F01B62ACBDBD300AE88DA /* UINavigationController+.swift in Sources */,
 				CD1C82A62ADB64E200F6DB50 /* DownloadImageManager.swift in Sources */,
@@ -702,6 +709,7 @@
 				221EB7C62ADA247D005044AF /* Reusable+.swift in Sources */,
 				CD1C829D2ADAA9A500F6DB50 /* Section.swift in Sources */,
 				CD029E132AD0B86A003D5FBD /* BorderColor.swift in Sources */,
+				CDA25DE62ADE084900D5DED5 /* GFItemInfoView.swift in Sources */,
 				CD1F019E2ACBD1DF00AE88DA /* AppDelegate.swift in Sources */,
 				CDB3C88E2AD28AB4001D5D3D /* StubURLSession.swift in Sources */,
 				CD1F01A02ACBD1DF00AE88DA /* SceneDelegate.swift in Sources */,

--- a/GithubFollower/GithubFollower.xcodeproj/project.pbxproj
+++ b/GithubFollower/GithubFollower.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		CDA25DE42ADDE5E700D5DED5 /* SFSymbols.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA25DE32ADDE5E700D5DED5 /* SFSymbols.swift */; };
 		CDA25DE62ADE084900D5DED5 /* GFItemInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA25DE52ADE084900D5DED5 /* GFItemInfoView.swift */; };
 		CDA25DE82ADE0D5300D5DED5 /* ItemInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA25DE72ADE0D5300D5DED5 /* ItemInfoType.swift */; };
+		CDA25DEA2ADE130F00D5DED5 /* GFItemInformationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA25DE92ADE130F00D5DED5 /* GFItemInformationViewController.swift */; };
 		CDB3C8612AD2199C001D5D3D /* NetworkManageable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3C8602AD2199C001D5D3D /* NetworkManageable.swift */; };
 		CDB3C8632AD21A0D001D5D3D /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3C8622AD21A0D001D5D3D /* NetworkManager.swift */; };
 		CDB3C86A2AD236C9001D5D3D /* JSONDecodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB3C8692AD236C9001D5D3D /* JSONDecodable.swift */; };
@@ -126,6 +127,7 @@
 		CDA25DE32ADDE5E700D5DED5 /* SFSymbols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SFSymbols.swift; sourceTree = "<group>"; };
 		CDA25DE52ADE084900D5DED5 /* GFItemInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GFItemInfoView.swift; sourceTree = "<group>"; };
 		CDA25DE72ADE0D5300D5DED5 /* ItemInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemInfoType.swift; sourceTree = "<group>"; };
+		CDA25DE92ADE130F00D5DED5 /* GFItemInformationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GFItemInformationViewController.swift; sourceTree = "<group>"; };
 		CDB3C8602AD2199C001D5D3D /* NetworkManageable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManageable.swift; sourceTree = "<group>"; };
 		CDB3C8622AD21A0D001D5D3D /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 		CDB3C8692AD236C9001D5D3D /* JSONDecodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodable.swift; sourceTree = "<group>"; };
@@ -207,6 +209,7 @@
 			children = (
 				CD029E0C2AD01715003D5FBD /* GFAlertViewController.swift */,
 				CDA25DDF2ADD24B400D5DED5 /* GFUserInfoHeaderViewController.swift */,
+				CDA25DE92ADE130F00D5DED5 /* GFItemInformationViewController.swift */,
 			);
 			path = Sub;
 			sourceTree = "<group>";
@@ -679,6 +682,7 @@
 				CD742FE62ACE2C48005681AD /* GFTitleLabel.swift in Sources */,
 				CD1F01B42ACBD9B700AE88DA /* FavoriteListViewController.swift in Sources */,
 				CD1C82B12ADC870100F6DB50 /* GFEmptyStateView.swift in Sources */,
+				CDA25DEA2ADE130F00D5DED5 /* GFItemInformationViewController.swift in Sources */,
 				CDB3C8612AD2199C001D5D3D /* NetworkManageable.swift in Sources */,
 				CD1F01BE2ACCE6F300AE88DA /* AssetImages.swift in Sources */,
 				CDA25DE22ADD265B00D5DED5 /* GFSecondaryTitleLabel.swift in Sources */,

--- a/GithubFollower/GithubFollower/Model/Enum/ItemInfoType.swift
+++ b/GithubFollower/GithubFollower/Model/Enum/ItemInfoType.swift
@@ -1,0 +1,13 @@
+//
+//  ItemInfoType.swift
+//  GithubFollower
+//
+//  Created by Minseong Kang on 10/17/23.
+//
+
+enum ItemInfoType {
+    case repos
+    case gists
+    case followers
+    case following
+}

--- a/GithubFollower/GithubFollower/Model/Enum/SFSymbols.swift
+++ b/GithubFollower/GithubFollower/Model/Enum/SFSymbols.swift
@@ -7,11 +7,23 @@
 
 enum SFSymbols {
     case mappinAndEllipse
+    case folder
+    case textAlignleft
+    case heart
+    case personTwo
     
     var imageName: String {
         switch self {
         case .mappinAndEllipse:
             return "mappin.and.ellipse"
+        case .folder:
+            return "folder"
+        case .textAlignleft:
+            return "text.alignleft"
+        case .heart:
+            return "heart"
+        case .personTwo:
+            return "person.2"
         }
     }
 }

--- a/GithubFollower/GithubFollower/View/CustomView/Views/GFItemInfoView.swift
+++ b/GithubFollower/GithubFollower/View/CustomView/Views/GFItemInfoView.swift
@@ -5,4 +5,103 @@
 //  Created by Minseong Kang on 10/17/23.
 //
 
-import Foundation
+import UIKit
+
+final class GFItemInfoView: UIView {
+    
+    let symbolImageView: UIImageView = UIImageView()
+    let titleLabel: GFTitleLabel = GFTitleLabel(textAlignment: .left, fontSize: 14)
+    let countLabel: GFTitleLabel = GFTitleLabel(textAlignment: .center, fontSize: 14)
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureSymbolImageView()
+        configureTitleLabel()
+        configureCountLabel()
+        
+        constraintsSymbolImageView()
+        constraintsTitleLabel()
+        constraintsConuntLabel()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+extension GFItemInfoView {
+    private func configureSymbolImageView() {
+        symbolImageView.contentMode = .scaleAspectFill
+        symbolImageView.tintColor = .label
+        symbolImageView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(symbolImageView)
+    }
+    
+    private func constraintsSymbolImageView() {
+        let width = (self.bounds.width) - (self.bounds.width - 20)
+        
+        NSLayoutConstraint.activate([
+            symbolImageView.topAnchor.constraint(equalTo: self.topAnchor),
+            symbolImageView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            symbolImageView.widthAnchor.constraint(equalToConstant: width),
+            symbolImageView.heightAnchor.constraint(equalTo: symbolImageView.widthAnchor, multiplier: 1),
+        ])
+    }
+    
+    private func configureTitleLabel() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(titleLabel)
+    }
+    
+    private func constraintsTitleLabel() {
+        let height = (self.bounds.height) - (self.bounds.height - 18)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.centerYAnchor.constraint(equalTo: symbolImageView.centerYAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: symbolImageView.trailingAnchor, constant: 12),
+            titleLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            titleLabel.heightAnchor.constraint(equalToConstant: height)
+        ])
+    }
+    
+    private func configureCountLabel() {
+        countLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(countLabel)
+    }
+    
+    private func constraintsConuntLabel() {
+        NSLayoutConstraint.activate([
+            countLabel.topAnchor.constraint(equalTo: symbolImageView.bottomAnchor, constant: 4),
+            countLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            countLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            countLabel.heightAnchor.constraint(equalTo: titleLabel.heightAnchor, multiplier: 1)
+        ])
+    }
+}
+
+extension GFItemInfoView {
+    func set(itemInfoType: ItemInfoType, withCount count: Int) {
+        switch itemInfoType {
+        case .repos:
+            guard let reposImage = UIImage(systemName: SFSymbols.folder.imageName) else { return }
+            symbolImageView.image = reposImage
+            titleLabel.text = "Public Repos"
+            countLabel.text = String(count)
+        case .gists:
+            guard let gistsImage = UIImage(systemName: SFSymbols.textAlignleft.imageName) else { return }
+            symbolImageView.image = gistsImage
+            titleLabel.text = "Public Gists"
+            countLabel.text = String(count)
+        case .followers:
+            guard let followersImage = UIImage(systemName: SFSymbols.heart.imageName) else { return }
+            symbolImageView.image = followersImage
+            titleLabel.text = "Followers"
+            countLabel.text = String(count)
+        case .following:
+            guard let followingImage = UIImage(systemName: SFSymbols.personTwo.imageName) else { return }
+            symbolImageView.image = followingImage
+            titleLabel.text = "Following"
+            countLabel.text = String(count)
+        }
+    }
+}

--- a/GithubFollower/GithubFollower/View/CustomView/Views/GFItemInfoView.swift
+++ b/GithubFollower/GithubFollower/View/CustomView/Views/GFItemInfoView.swift
@@ -1,0 +1,8 @@
+//
+//  GFItemInfoView.swift
+//  GithubFollower
+//
+//  Created by Minseong Kang on 10/17/23.
+//
+
+import Foundation

--- a/GithubFollower/GithubFollower/ViewController/Core/UserInformationViewController.swift
+++ b/GithubFollower/GithubFollower/ViewController/Core/UserInformationViewController.swift
@@ -11,7 +11,7 @@ final class UserInformationViewController: UIViewController {
     
     let headerView: UIView = UIView()
     let githubRepoView: UIView = UIView()
-    let gitgistView: UIView = UIView()
+    let getFollowerView: UIView = UIView()
     
     var networkManager: NetworkManager
     var username: String?
@@ -112,20 +112,20 @@ extension UserInformationViewController {
     }
     
     private func configureGitgistView() {
-        gitgistView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(gitgistView)
+        getFollowerView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(getFollowerView)
         
-        gitgistView.backgroundColor = .systemBlue
+        getFollowerView.backgroundColor = .systemBlue
     }
     
     private func constraintsGitgistView() {
         let height = (view.bounds.height) - (view.bounds.height - 140)
         
         NSLayoutConstraint.activate([
-            gitgistView.topAnchor.constraint(equalTo: githubRepoView.bottomAnchor, constant: padding),
-            gitgistView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: padding),
-            gitgistView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -padding),
-            gitgistView.heightAnchor.constraint(equalToConstant: height)
+            getFollowerView.topAnchor.constraint(equalTo: githubRepoView.bottomAnchor, constant: padding),
+            getFollowerView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: padding),
+            getFollowerView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -padding),
+            getFollowerView.heightAnchor.constraint(equalToConstant: height)
         ])
     }
     

--- a/GithubFollower/GithubFollower/ViewController/Sub/GFItemInformationViewController.swift
+++ b/GithubFollower/GithubFollower/ViewController/Sub/GFItemInformationViewController.swift
@@ -1,0 +1,72 @@
+//
+//  GFItemInformationViewController.swift
+//  GithubFollower
+//
+//  Created by Minseong Kang on 10/17/23.
+//
+
+import UIKit
+
+final class GFItemInformationViewController: UIViewController {
+    
+    let stackView: UIStackView = UIStackView()
+    let reposAndGistView: GFItemInfoView = GFItemInfoView()
+    let followersAndFollowingView: GFItemInfoView = GFItemInfoView()
+    let commonButton: GFButton = GFButton()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        configureBackgroundView()
+        configureStackView()
+        
+        constraintsStackView()
+        constraintsCommonButton()
+    }
+}
+
+extension GFItemInformationViewController {
+    private func configureBackgroundView() {
+        let cornerRadius = (view.bounds.width) - (view.bounds.width - 18)
+        view.layer.cornerRadius = cornerRadius
+        view.backgroundColor = .secondarySystemBackground
+    }
+    
+    private func configureStackView() {
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(stackView)
+        
+        stackView.axis = .horizontal
+        stackView.distribution = .equalSpacing
+        
+        stackView.addArrangedSubview(reposAndGistView)
+        stackView.addArrangedSubview(followersAndFollowingView)
+    }
+    
+    private func constraintsStackView() {
+        let padding: CGFloat = 20
+        
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: view.topAnchor, constant: padding),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: padding),
+            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -padding),
+            stackView.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 1/2)
+        ])
+    }
+    
+    private func configureCommonButton() {
+        commonButton.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(commonButton)
+    }
+    
+    private func constraintsCommonButton() {
+        let padding: CGFloat = 20
+        
+        NSLayoutConstraint.activate([
+            commonButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -padding),
+            commonButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: padding),
+            commonButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -padding),
+            commonButton.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 1/2, constant: -16)
+        ])
+    }
+}


### PR DESCRIPTION
- gitgistView의 프로퍼티 명을 바꾸었습니다.
- ItemInfoView를 타입별로 Custom하게 사용하기 위한 열거형을 생성 및 구현하였습니다.
- SFSymbols 열거형에 case를 추가하였습니다.
- ItemType별 정보를 각기 다르게 보여주는 Custom한 View를 생성 및 구현하였습니다.
- 유저의 정보(repo,gist,follower,following) 정보를 담고 정보를 보여주기 위한 컨테이너 뷰 컨트롤러를 생성 및 구현하였습니다.